### PR TITLE
docs: add Spanish README

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -1,0 +1,64 @@
+
+
+# Tasko: La Aplicación de Gestión de Tareas de Código Abierto
+
+[![codecov](https://codecov.io/github/ahmadk953/tasko/graph/badge.svg?token=IJ8U9B49RU)](https://codecov.io/github/ahmadk953/tasko)
+
+> [!WARNING]
+> **Este sitio web aún está en un estado alfa**. Habrá muchos errores y funciones rotas o faltantes. Este sitio web **NO** está listo para producción y faltan muchas características esenciales, como el cifrado de datos. Esta aplicación también puede fallar en cualquier momento y todos tus datos podrían perderse. **La disponibilidad de este proyecto no está garantizada**.
+
+## Acerca de
+
+![Tasko Home Page](https://cloud-eohgwrlid-hack-club-bot.vercel.app/0screenshot.jpeg)
+
+Tasko es un sitio web que te ayuda a gestionar tus tareas de manera eficiente mediante el uso de tableros kanban. Los tableros kanban son una forma visual de organizar tu trabajo en diferentes etapas, como por hacer, en progreso y completado. Con Tasko, puedes crear y personalizar tus propios tableros kanban y añadir tareas. Tasko está diseñado para ser simple, intuitivo y flexible, para que puedas concentrarte en completar tus tareas y alcanzar tus objetivos. [¡Prueba Tasko Hoy!](https://tasko.ahmadk953.org/)
+
+## Documentación
+
+> [!WARNING]
+> La documentación no está completa y aún está en progreso.
+
+La documentación se puede encontrar [aquí](https://docs.tasko.ahmadk953.org/).
+
+## Hoja de Ruta
+
+Esto se publicará en el sitio en breve, pero por ahora, la hoja de ruta se enumerará aquí.
+
+- [ ] Opciones de ordenamiento de tableros (Página de Tableros)
+- [ ] Agregar colaboración en tiempo real _En Progreso - Parte 1 Finalizada_
+- [ ] Agregar cifrado de extremo a extremo de la base de datos (para datos del usuario como títulos y descripciones de tarjetas, e información de suscripción)
+- [ ] Soporte de texto enriquecido en descripciones de tarjetas
+- [ ] Versión autoalojada
+- [ ] Mover la hoja de ruta al sitio web _En Progreso - Comenzando con una página MDX básica_
+
+## Contribuciones y Desarrollo
+
+### Comandos de Desarrollo
+
+Instalar dependencias: ``yarn install --immutable``
+
+Iniciar servidor de desarrollo: ``yarn dev``
+
+Construcción para producción: ``yarn build``
+
+Iniciar servidor de producción: ``yarn start``
+
+Linter: ``yarn lint``
+
+Verificar formato: ``yarn format``
+
+Corregir formato: ``yarn format:fix``
+
+Pruebas: ``yarn test``
+
+Cobertura: ``yarn coverage``
+
+Por favor, asegúrate de ejecutar el linter, verificar el formato y realizar las pruebas (usando los comandos listados arriba) antes de enviar un Pull Request.
+
+## Legal
+
+Política de Privacidad _Se agregará próximamente_
+
+Términos de Servicio _Se agregarán junto con la política de privacidad_
+
+[Licencia](https://github.com/ahmadk953/tasko/blob/main/LICENCE) _Se agregará al sitio web junto con la política de privacidad y los términos de servicio_


### PR DESCRIPTION
Adds README.es-ES.md alongside the original documentation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a Spanish translation of the README to make the docs accessible for Spanish-speaking users. Introduces `README.es-ES.md` mirroring the main README, including warnings, docs link, roadmap, development commands, and legal placeholders.

<sup>Written for commit 287083549ae04c2c9ce155383961f1fe5e966d14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ahmadk953/tasko/pull/1717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

